### PR TITLE
added description for desktop file

### DIFF
--- a/extra/org.getmonero.Monero.desktop
+++ b/extra/org.getmonero.Monero.desktop
@@ -1,5 +1,7 @@
 [Desktop Entry]
 Name=Monero GUI
+GenericName=Monero-GUI
+Comment=Monero GUI
 Exec=monero-wallet-gui
 Type=Application
 Terminal=false


### PR DESCRIPTION
Upstream already has an example desktop file in src/qt/utils.cpp
It bothered me that there was no description in my application menu. So here it is.