### PR TITLE
update deprecated boost url

### DIFF
--- a/org.getmonero.Monero.yaml
+++ b/org.getmonero.Monero.yaml
@@ -67,7 +67,7 @@ modules:
           - ./b2 -j$FLATPAK_BUILDER_N_JOBS install variant=release --layout=system
         sources:
           - type: archive
-            url: https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz
+            url: https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
             sha256: a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724
 
       - name: protobuf


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
